### PR TITLE
Switch to Ansible installer RPM

### DIFF
--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,13 @@
+---
+include:
+  - changelogs
+  - docs
+  - meta
+  - playbooks
+  - plugins
+  - roles
+formatter:
+  type: basic
+  indent: 2
+  retain_line_breaks: true
+  include_document_start: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,20 @@ Aoc.Controller_Demo_Config Release Notes
 .. contents:: Topics
 
 
+v1.2.0
+======
+
+Release Summary
+---------------
+
+Deploy the AAP installer via subscription-manager and DNF
+
+Minor Changes
+-------------
+
+- Become sudo when running the installer tasks since logs and inventory will be in a root owned directory.
+- Removed the need to provide the AAP installer by installing the installer via DNF.
+
 v1.1.0
 ======
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ It is recommended that you create a custom AMI that you may then use to deploy R
 
 ### Ansible Automation Platform Installer
 
-This collection expects that the most recent version of the [Ansible Automation Platform installer][aap-installer] is downloaded locally and can be moved to the deployment to install AAP.
-
-This collection expects the standard "setup" file, not the "bundle".  And, it is not yet tested with the containerized installer.
+This collection uses subscription manager to install the AAP installer onto the AWS virtual machines.
 
 ### Roles
 
@@ -75,18 +73,16 @@ This collection includes the following roles.  Each role has default variables a
 
 The following identifies the variables that you **must** set before running the deployment.  You may create a variable file that you can pass to the deployment playbook to set these variables.
 
-| Variable                              | Description                                                                                                               |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `infrastructure_region`               | The AWS region that the infrastructure will be deployed into.                                                             |
-| `infrastructure_db_username`          | The PostgreSQL admin username that will be used for databases.                                                            |
-| `infrastructure_db_password`          | The PostgreSQL admin password that will be used for databases.                                                            |
-| `aap_installer_src_path`              | The path to the AAP installer file (.tgz) on the local machine. This file will be uploaded to a VM during the deployment. |
-| `aap_installer_unarchive_folder_name` | The name of the root folder in the extracted installer file.  This will change from AAP version to version.               |
-| `aap_admin_password`                  | The admin password to create for Ansible Automation Platform applications.                                                |
-| `aap_installer_ssh_key`               | The name of the SSH key on the local machine that will be used to connect to the installer VM and other VMs deployed.     |
-| `aap_installer_ssh_key_src`           | The full path to the SSH key on the local machine.                                                                        |
-| `aap_red_hat_username`                | Your Red Hat account username that will be used to register RHEL instances with subscription manager.                     |
-| `aap_red_hat_password`                | Your Red Hat account password that will be used to register RHEL instances with subscription manager.                     |
+| Variable                     | Description                                                                                                           |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `infrastructure_region`      | The AWS region that the infrastructure will be deployed into.                                                         |
+| `infrastructure_db_username` | The PostgreSQL admin username that will be used for databases.                                                        |
+| `infrastructure_db_password` | The PostgreSQL admin password that will be used for databases.                                                        |
+| `aap_admin_password`         | The admin password to create for Ansible Automation Platform applications.                                            |
+| `aap_installer_ssh_key`      | The name of the SSH key on the local machine that will be used to connect to the installer VM and other VMs deployed. |
+| `aap_installer_ssh_key_src`  | The full path to the SSH key on the local machine.                                                                    |
+| `aap_red_hat_username`       | Your Red Hat account username that will be used to register RHEL instances with subscription manager.                 |
+| `aap_red_hat_password`       | Your Red Hat account password that will be used to register RHEL instances with subscription manager.                 |
 
 The following is an example of a variables file with required and optional fields that can be used to tailor a deployment.  This example uses a custom AMI that was created with [Image Builder][image-builder], it provides a certificate and values to create a load balancer in front of Automation Controller, and it will run the AAP installer once the infrastructure is configured.
 
@@ -123,9 +119,6 @@ infrastructure_create_controller_lb: true
 infrastructure_cert_path: /Users/scott/Downloads/cert.pem
 infrastructure_cert_key_path: /Users/scott/Downloads/key.pem
 infrastructure_cert_domain_name: controller.my.custom.domain
-
-aap_installer_src_path: ~/Downloads/ansible-automation-platform-setup-2.4-2.tar.gz
-aap_installer_unarchive_folder_name: ansible-automation-platform-setup-2.4-2
 
 aap_installer_ssh_key: aws_test_key
 aap_installer_ssh_key_src: "~/.ssh/{{ aap_installer_ssh_key }}"

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,80 +1,96 @@
----
 ancestor: null
 releases:
   1.0.0:
     changes:
       major_changes:
-        - Deploy the RPM-based Ansible Automation Platform installer via RHEL-based virtual machines on AWS.
+      - Deploy the RPM-based Ansible Automation Platform installer via RHEL-based
+        virtual machines on AWS.
       release_summary: Initial release
     fragments:
-      - initial.yaml
+    - initial.yaml
     release_date: '2023-11-06'
   1.0.1:
     changes:
       minor_changes:
-        - Added EDA server public IP address to the list of ALLOWED_HOSTS in EDA.
-        - Changed include role statements to use FQRN.
-        - Update task labels to be more descriptive.
-        - Update the installer unarchive process to avoid errors.
-        - Updated host group names for clarity.
+      - Added EDA server public IP address to the list of ALLOWED_HOSTS in EDA.
+      - Changed include role statements to use FQRN.
+      - Update task labels to be more descriptive.
+      - Update the installer unarchive process to avoid errors.
+      - Updated host group names for clarity.
       release_summary: Bug fixes and improvements.
     fragments:
-      - installer-improvements.yml
+    - installer-improvements.yml
     release_date: '2023-11-09'
   1.0.2:
     changes:
       minor_changes:
-        - Added a default for `aap_installer_ssh_key_dest` so that it is not required and will default to the ec2-user's ssh directory.
-        - Added ansible.cfg file with SSH args to keep connection open during AAP install.
-        - Added output steps to make it easier to find connection details after deployment.
-        - Updated README to add SSH info.
-        - Updated get existing VMs logic to make it more reusable.
+      - Added a default for `aap_installer_ssh_key_dest` so that it is not required
+        and will default to the ec2-user's ssh directory.
+      - Added ansible.cfg file with SSH args to keep connection open during AAP install.
+      - Added output steps to make it easier to find connection details after deployment.
+      - Updated README to add SSH info.
+      - Updated get existing VMs logic to make it more reusable.
       release_summary: Improvements to the install steps to improve experience.
     fragments:
-      - install-changes.yml
+    - install-changes.yml
     release_date: '2023-11-09'
   1.0.3:
     changes:
       minor_changes:
-        - Added variable to control removing SSH key from install server regardless of installer outcome.
-        - README updates.
+      - Added variable to control removing SSH key from install server regardless
+        of installer outcome.
+      - README updates.
       release_summary: General updates and bug fixes
     fragments:
-      - bugfixes2.yml
+    - bugfixes2.yml
     release_date: '2023-11-10'
   1.0.4:
     changes:
       minor_changes:
-        - Added Ansible tags where missing to infrastructure role.
-        - Updated AWS tagging to allow for user defined tags along with collection tag opinions.
+      - Added Ansible tags where missing to infrastructure role.
+      - Updated AWS tagging to allow for user defined tags along with collection tag
+        opinions.
       release_summary: Updates to tagging.
     fragments:
-      - tags.yml
+    - tags.yml
     release_date: '2023-11-14'
   1.0.5:
     changes:
       minor_changes:
-        - Prevent user defined tags from overwriting persistent tags.
+      - Prevent user defined tags from overwriting persistent tags.
       release_summary: Bug fixes
     fragments:
-      - bugfixes3.yml
+    - bugfixes3.yml
     release_date: '2023-11-15'
   1.0.6:
     changes:
       minor_changes:
-        - Change license to GPLv3.
+      - Change license to GPLv3.
       release_summary: Update the license to align with AAP
     fragments:
-      - license.yml
+    - license.yml
     release_date: '2023-11-16'
   1.1.0:
     changes:
       minor_changes:
-        - Added PostgreSQL commands to account for the limit of one DB per-RDS instance in the AWS collection
-        - Moved subscription manager and dnf tasks from playbooks into role tasks
-        - Update DB logic to account for a single RDS instance
-        - Update precommit dependencies
-      release_summary: Update the deployment so that a single RDS instance is used for all AAP apps.
+      - Added PostgreSQL commands to account for the limit of one DB per-RDS instance
+        in the AWS collection
+      - Moved subscription manager and dnf tasks from playbooks into role tasks
+      - Update DB logic to account for a single RDS instance
+      - Update precommit dependencies
+      release_summary: Update the deployment so that a single RDS instance is used
+        for all AAP apps.
     fragments:
-      - consolidatedb.yml
+    - consolidatedb.yml
     release_date: '2023-11-29'
+  1.2.0:
+    changes:
+      minor_changes:
+      - Become sudo when running the installer tasks since logs and inventory will
+        be in a root owned directory.
+      - Removed the need to provide the AAP installer by installing the installer
+        via DNF.
+      release_summary: Deploy the AAP installer via subscription-manager and DNF
+    fragments:
+    - use-installer.yml
+    release_date: '2023-12-07'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,85 +1,80 @@
+---
 ancestor: null
 releases:
   1.0.0:
     changes:
       major_changes:
-      - Deploy the RPM-based Ansible Automation Platform installer via RHEL-based
-        virtual machines on AWS.
+        - Deploy the RPM-based Ansible Automation Platform installer via RHEL-based virtual machines on AWS.
       release_summary: Initial release
     fragments:
-    - initial.yaml
+      - initial.yaml
     release_date: '2023-11-06'
   1.0.1:
     changes:
       minor_changes:
-      - Added EDA server public IP address to the list of ALLOWED_HOSTS in EDA.
-      - Changed include role statements to use FQRN.
-      - Update task labels to be more descriptive.
-      - Update the installer unarchive process to avoid errors.
-      - Updated host group names for clarity.
+        - Added EDA server public IP address to the list of ALLOWED_HOSTS in EDA.
+        - Changed include role statements to use FQRN.
+        - Update task labels to be more descriptive.
+        - Update the installer unarchive process to avoid errors.
+        - Updated host group names for clarity.
       release_summary: Bug fixes and improvements.
     fragments:
-    - installer-improvements.yml
+      - installer-improvements.yml
     release_date: '2023-11-09'
   1.0.2:
     changes:
       minor_changes:
-      - Added a default for `aap_installer_ssh_key_dest` so that it is not required
-        and will default to the ec2-user's ssh directory.
-      - Added ansible.cfg file with SSH args to keep connection open during AAP install.
-      - Added output steps to make it easier to find connection details after deployment.
-      - Updated README to add SSH info.
-      - Updated get existing VMs logic to make it more reusable.
+        - Added a default for `aap_installer_ssh_key_dest` so that it is not required and will default to the ec2-user's ssh directory.
+        - Added ansible.cfg file with SSH args to keep connection open during AAP install.
+        - Added output steps to make it easier to find connection details after deployment.
+        - Updated README to add SSH info.
+        - Updated get existing VMs logic to make it more reusable.
       release_summary: Improvements to the install steps to improve experience.
     fragments:
-    - install-changes.yml
+      - install-changes.yml
     release_date: '2023-11-09'
   1.0.3:
     changes:
       minor_changes:
-      - Added variable to control removing SSH key from install server regardless
-        of installer outcome.
-      - README updates.
+        - Added variable to control removing SSH key from install server regardless of installer outcome.
+        - README updates.
       release_summary: General updates and bug fixes
     fragments:
-    - bugfixes2.yml
+      - bugfixes2.yml
     release_date: '2023-11-10'
   1.0.4:
     changes:
       minor_changes:
-      - Added Ansible tags where missing to infrastructure role.
-      - Updated AWS tagging to allow for user defined tags along with collection tag
-        opinions.
+        - Added Ansible tags where missing to infrastructure role.
+        - Updated AWS tagging to allow for user defined tags along with collection tag opinions.
       release_summary: Updates to tagging.
     fragments:
-    - tags.yml
+      - tags.yml
     release_date: '2023-11-14'
   1.0.5:
     changes:
       minor_changes:
-      - Prevent user defined tags from overwriting persistent tags.
+        - Prevent user defined tags from overwriting persistent tags.
       release_summary: Bug fixes
     fragments:
-    - bugfixes3.yml
+      - bugfixes3.yml
     release_date: '2023-11-15'
   1.0.6:
     changes:
       minor_changes:
-      - Change license to GPLv3.
+        - Change license to GPLv3.
       release_summary: Update the license to align with AAP
     fragments:
-    - license.yml
+      - license.yml
     release_date: '2023-11-16'
   1.1.0:
     changes:
       minor_changes:
-      - Added PostgreSQL commands to account for the limit of one DB per-RDS instance
-        in the AWS collection
-      - Moved subscription manager and dnf tasks from playbooks into role tasks
-      - Update DB logic to account for a single RDS instance
-      - Update precommit dependencies
-      release_summary: Update the deployment so that a single RDS instance is used
-        for all AAP apps.
+        - Added PostgreSQL commands to account for the limit of one DB per-RDS instance in the AWS collection
+        - Moved subscription manager and dnf tasks from playbooks into role tasks
+        - Update DB logic to account for a single RDS instance
+        - Update precommit dependencies
+      release_summary: Update the deployment so that a single RDS instance is used for all AAP apps.
     fragments:
-    - consolidatedb.yml
+      - consolidatedb.yml
     release_date: '2023-11-29'

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,3 +1,4 @@
+---
 changelog_filename_template: ../CHANGELOG.rst
 changelog_filename_version_depth: 0
 changes_file: changelog.yaml
@@ -11,22 +12,22 @@ prelude_section_name: release_summary
 prelude_section_title: Release Summary
 sanitize_changelog: true
 sections:
-- - major_changes
-  - Major Changes
-- - minor_changes
-  - Minor Changes
-- - breaking_changes
-  - Breaking Changes / Porting Guide
-- - deprecated_features
-  - Deprecated Features
-- - removed_features
-  - Removed Features (previously deprecated)
-- - security_fixes
-  - Security Fixes
-- - bugfixes
-  - Bugfixes
-- - known_issues
-  - Known Issues
+  - - major_changes
+    - Major Changes
+  - - minor_changes
+    - Minor Changes
+  - - breaking_changes
+    - Breaking Changes / Porting Guide
+  - - deprecated_features
+    - Deprecated Features
+  - - removed_features
+    - Removed Features (previously deprecated)
+  - - security_fixes
+    - Security Fixes
+  - - bugfixes
+    - Bugfixes
+  - - known_issues
+    - Known Issues
 title: Aoc.Controller_Demo_Config
 trivial_section_name: trivial
 use_fqcn: true

--- a/changelogs/fragments/use-installer.yml
+++ b/changelogs/fragments/use-installer.yml
@@ -1,0 +1,4 @@
+---
+release_summary: Deploy the AAP installer via subscription-manager and DNF
+minor_changes:
+  - Removed the need to provide the AAP installer by installing the installer via DNF.

--- a/changelogs/fragments/use-installer.yml
+++ b/changelogs/fragments/use-installer.yml
@@ -1,5 +1,0 @@
----
-release_summary: Deploy the AAP installer via subscription-manager and DNF
-minor_changes:
-  - Removed the need to provide the AAP installer by installing the installer via DNF.
-  - Become sudo when running the installer tasks since logs and inventory will be in a root owned directory.

--- a/changelogs/fragments/use-installer.yml
+++ b/changelogs/fragments/use-installer.yml
@@ -2,3 +2,4 @@
 release_summary: Deploy the AAP installer via subscription-manager and DNF
 minor_changes:
   - Removed the need to provide the AAP installer by installing the installer via DNF.
+  - Become sudo when running the installer tasks since logs and inventory will be in a root owned directory.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: lab
 name: aws_deployment
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.1.0
+version: 1.2.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/playbooks/deploy_aap.yml
+++ b/playbooks/deploy_aap.yml
@@ -48,7 +48,7 @@
 - name: Install AAP
   hosts: installer
   gather_facts: false
-  become: false
+  become: true
   vars:
     aap_controller_hosts: "{{ groups.controller_private }}"
     aap_ee_hosts: "{{ groups.execution_private | default('') }}"

--- a/playbooks/deploy_aap.yml
+++ b/playbooks/deploy_aap.yml
@@ -48,7 +48,7 @@
 - name: Install AAP
   hosts: installer
   gather_facts: false
-  become: true
+  become: false
   vars:
     aap_controller_hosts: "{{ groups.controller_private }}"
     aap_ee_hosts: "{{ groups.execution_private | default('') }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,10 +1,12 @@
 ---
 collections:
   - name: amazon.aws
-    version: 6.5.0
+    version: ">=6.5.0"
   - name: ansible.utils
-    version: 2.11.0
+    version: ">=2.11.0"
   - name: community.aws
-    version: 6.3.0
+    version: ">=6.3.0"
   - name: community.general
-    version: 7.5.0
+    version: ">=8.0.0"
+  - name: community.postgresql
+    version: ">=3.2.0"

--- a/roles/aap/defaults/main.yml
+++ b/roles/aap/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
-aap_installer_unarchive_path: /home/ec2-user/
-aap_installer_unarchive_folder_name: ansible-automation-platform-setup-2.4-2
+aap_installer_home_dir: /home/ec2-user/
 aap_installer_path: /opt/ansible-automation-platform/installer/
+aap_installer_log_path: "{{ aap_installer_home_dir }}setup.log"
 aap_installer_inventory_path: "{{ aap_installer_path }}inventory"
 aap_ssh_path: /home/ec2-user/.ssh/
 aap_installer_ssh_key_dest: "{{ aap_ssh_path }}{{ aap_installer_ssh_key }}"

--- a/roles/aap/defaults/main.yml
+++ b/roles/aap/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 aap_installer_home_dir: /home/ec2-user/
 aap_installer_path: /opt/ansible-automation-platform/installer/
-aap_installer_log_path: "{{ aap_installer_home_dir }}setup.log"
+aap_installer_log_path: /tmp
 aap_installer_inventory_path: "{{ aap_installer_path }}inventory"
 aap_ssh_path: /home/ec2-user/.ssh/
 aap_installer_ssh_key_dest: "{{ aap_ssh_path }}{{ aap_installer_ssh_key }}"

--- a/roles/aap/defaults/main.yml
+++ b/roles/aap/defaults/main.yml
@@ -1,10 +1,9 @@
 ---
 aap_installer_unarchive_path: /home/ec2-user/
 aap_installer_unarchive_folder_name: ansible-automation-platform-setup-2.4-2
-aap_installer_path: "{{ aap_installer_unarchive_path }}{{ aap_installer_unarchive_folder_name }}/"
+aap_installer_path: /opt/ansible-automation-platform/installer/
 aap_installer_inventory_path: "{{ aap_installer_path }}inventory"
 aap_ssh_path: /home/ec2-user/.ssh/
 aap_installer_ssh_key_dest: "{{ aap_ssh_path }}{{ aap_installer_ssh_key }}"
 aap_run_installer: true
-aap_remove_installer_after_install: true
 aap_remove_ssh_key_from_install_server: true

--- a/roles/aap/tasks/aap_setup.yml
+++ b/roles/aap/tasks/aap_setup.yml
@@ -4,7 +4,7 @@
     msg: "This process can take a long time to complete.  If you want to follow the logs of the installer, then SSH into the installer server and follow the setup.log file at `{{ aap_installer_path }}setup.log`."
 
 - name: Run the AAP install script
-  ansible.builtin.shell: "ANSIBLE_BECOME_METHOD='sudo' ANSIBLE_BECOME=True {{ aap_installer_path }}setup.sh -p {{ aap_installer_log_path }}"
+  ansible.builtin.shell: "ANSIBLE_BECOME_METHOD='sudo' ANSIBLE_BECOME=True {{ aap_installer_path }}setup.sh"
   register: install
   changed_when: install.rc != 1
   failed_when: install.rc == 1

--- a/roles/aap/tasks/aap_setup.yml
+++ b/roles/aap/tasks/aap_setup.yml
@@ -3,8 +3,19 @@
   ansible.builtin.debug:
     msg: "This process can take a long time to complete.  If you want to follow the logs of the installer, then SSH into the installer server and follow the setup.log file at `{{ aap_installer_path }}setup.log`."
 
+- name: Touch the log file to ensure that `ec2-user` can write to it.
+  ansible.builtin.file:
+    path: "{{ aap_installer_path }}setup.log"
+    state: touch
+    owner: ec2-user
+    group: ec2-user
+  become: true
+
 - name: Run the AAP install script
-  ansible.builtin.shell: "ANSIBLE_BECOME_METHOD='sudo' ANSIBLE_BECOME=True {{ aap_installer_path }}setup.sh"
+  ansible.builtin.shell: "{{ aap_installer_path }}setup.sh"
+  environment:
+    ANSIBLE_BECOME_METHOD: sudo
+    ANSIBLE_BECOME: "True"
   register: install
   changed_when: install.rc != 1
   failed_when: install.rc == 1

--- a/roles/aap/tasks/aap_setup.yml
+++ b/roles/aap/tasks/aap_setup.yml
@@ -4,7 +4,7 @@
     msg: "This process can take a long time to complete.  If you want to follow the logs of the installer, then SSH into the installer server and follow the setup.log file at `{{ aap_installer_path }}setup.log`."
 
 - name: Run the AAP install script
-  ansible.builtin.shell: "ANSIBLE_BECOME_METHOD='sudo' ANSIBLE_BECOME=True {{ aap_installer_path }}setup.sh -io {{ aap_installer_inventory_path }}"
+  ansible.builtin.shell: "ANSIBLE_BECOME_METHOD='sudo' ANSIBLE_BECOME=True {{ aap_installer_path }}setup.sh -p {{ aap_installer_log_path }}"
   register: install
   changed_when: install.rc != 1
   failed_when: install.rc == 1

--- a/roles/aap/tasks/aap_setup.yml
+++ b/roles/aap/tasks/aap_setup.yml
@@ -4,7 +4,7 @@
     msg: "This process can take a long time to complete.  If you want to follow the logs of the installer, then SSH into the installer server and follow the setup.log file at `{{ aap_installer_path }}setup.log`."
 
 - name: Run the AAP install script
-  ansible.builtin.shell: "ANSIBLE_BECOME_METHOD='sudo' ANSIBLE_BECOME=True {{ aap_installer_path }}setup.sh"
+  ansible.builtin.shell: "ANSIBLE_BECOME_METHOD='sudo' ANSIBLE_BECOME=True {{ aap_installer_path }}setup.sh -io {{ aap_installer_inventory_path }}"
   register: install
   changed_when: install.rc != 1
   failed_when: install.rc == 1

--- a/roles/aap/tasks/create_inventory.yml
+++ b/roles/aap/tasks/create_inventory.yml
@@ -9,3 +9,4 @@
   ansible.builtin.template:
     src: inventory.j2
     dest: "{{ aap_installer_inventory_path }}"
+  become: true

--- a/roles/aap/tasks/main.yml
+++ b/roles/aap/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-- name: Unarchive installer
-  ansible.builtin.import_tasks: unarchive_installer.yml
-
 - name: Create inventory
   ansible.builtin.import_tasks: create_inventory.yml
 

--- a/roles/aap/tasks/post_install_cleanup.yml
+++ b/roles/aap/tasks/post_install_cleanup.yml
@@ -1,13 +1,4 @@
 ---
-- name: Remove installer
-  ansible.builtin.file:
-    path: "{{ aap_installer_path }}"
-    state: absent
-  when:
-    - aap_run_installer
-    - aap_remove_installer_after_install
-    - install.rc != 1
-
 - name: Remove SSH key
   ansible.builtin.file:
     path: "{{ aap_installer_ssh_key_dest }}"

--- a/roles/aap/tasks/unarchive_installer.yml
+++ b/roles/aap/tasks/unarchive_installer.yml
@@ -1,6 +1,0 @@
----
-- name: Copy and unarchive inventory to install server
-  ansible.builtin.unarchive:
-    src: "{{ aap_installer_src_path }}"
-    dest: "{{ aap_installer_unarchive_path }}"
-    owner: ec2-user

--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -22,9 +22,10 @@ infrastructure_vpc_subnets:
 # Compute
 infrastructure_assign_public_ip: true
 infrastructure_delete_on_termination: true
+infrastructure_architecture: x86_64
 
 infrastructure_ami_filter:
-  architecture: x86_64
+  architecture: "{{ infrastructure_architecture }}"
   owner-id: "309956199498"
   name: "RHEL-9.2.*_HVM-*"
 
@@ -64,3 +65,7 @@ infrastructure_db_db_instance_class: db.m5d.xlarge
 infrastructure_db_storage_type: io1
 infrastructure_db_storage_iops: 5000
 infrastructure_db_allocated_storage: 100
+
+# RHEL
+infrastructure_aap_version: "2.4"
+infrastructure_rhel_version: "9"

--- a/roles/infrastructure/tasks/ami.yml
+++ b/roles/infrastructure/tasks/ami.yml
@@ -9,7 +9,7 @@
         filters: "{{ infrastructure_ami_filter }}"
       register: infrastructure_vm_amis
       when: infrastructure_vm_ami is not defined
-    
+
     - name: Output RHEL AMI list
       ansible.builtin.debug:
         var: infrastructure_vm_amis
@@ -18,11 +18,11 @@
       ansible.builtin.set_fact:
         infrastructure_vm_ami: >-
           {{ (infrastructure_vm_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date'))[-1].image_id }}
-      when: 
+      when:
         - infrastructure_vm_ami is not defined
         - infrastructure_vm_amis is defined
         - infrastructure_vm_amis.images | length > 0
-    
+
     - name: Debug selected AMI
       ansible.builtin.debug:
         var: infrastructure_vm_ami
@@ -52,7 +52,7 @@
 
 - name: Set Stats AMI
   ansible.builtin.set_stats:
-    data: 
+    data:
       controller_ami: "{{ infrastructure_controller_ami }}"
       hub_ami: "{{ infrastructure_hub_ami }}"
       eda_ami: "{{ infrastructure_eda_ami }}"

--- a/roles/infrastructure/tasks/controller.yml
+++ b/roles/infrastructure/tasks/controller.yml
@@ -21,7 +21,7 @@
         or groups.installer | length == 0)
       ansible.builtin.add_host:
         groups:
-        - installer
+          - installer
         name: "{{ infrastructure_existing_vm.instances[0].public_ip_address }}"
       tags:
         - controller

--- a/roles/infrastructure/tasks/database.yml
+++ b/roles/infrastructure/tasks/database.yml
@@ -38,7 +38,7 @@
     storage_type: "{{ infrastructure_db_storage_type }}"
     iops: "{{ infrastructure_db_storage_iops | default(None) }}"
     allocated_storage: "{{ infrastructure_db_allocated_storage }}"
-    vpc_security_group_ids: 
+    vpc_security_group_ids:
       - "{{ infrastructure_security_group.group_id }}"
     db_subnet_group_name: "{{ infrastructure_db_subnet_group.subnet_group.name }}"
     tags: "{{ db_tags }}"

--- a/roles/infrastructure/tasks/deployment.yml
+++ b/roles/infrastructure/tasks/deployment.yml
@@ -15,7 +15,7 @@
 
 - name: Set deployment stat
   ansible.builtin.set_stats:
-    data: 
+    data:
       deployment_id: "{{ deployment_id }}"
     per_host: false
   tags:

--- a/roles/infrastructure/tasks/vms/create.yml
+++ b/roles/infrastructure/tasks/vms/create.yml
@@ -70,7 +70,7 @@
   when: groups.installer is not defined
   ansible.builtin.add_host:
     groups:
-     - installer
+      - installer
     name: "{{ infrastructure_ec2_instance.instances[0].public_ip_address }}"
   tags:
     - controller

--- a/roles/infrastructure/tasks/vms/dnf.yml
+++ b/roles/infrastructure/tasks/vms/dnf.yml
@@ -12,6 +12,7 @@
   ansible.builtin.dnf:
     name:
       - python3-psycopg2
+      - ansible-automation-platform-installer
     state: latest
   tags:
     - controller

--- a/roles/infrastructure/tasks/vms/subscription_manager.yml
+++ b/roles/infrastructure/tasks/vms/subscription_manager.yml
@@ -18,3 +18,12 @@
     - controller
     - hub
     - eda
+
+- name: Enable the AAP installer repository
+  ansible.builtin.command: "sudo subscription-manager repos --enable ansible-automation-platform-{{ infrastructure_aap_version }}-for-rhel-{{ infrastructure_rhel_version }}-{{ infrastructure_architecture }}-rpms"
+  register: aap_installer_install
+  failed_when: aap_installer_install.rc == 1
+  tags:
+    - controller
+    - hub
+    - eda


### PR DESCRIPTION
Switch the process so that the AAP installer is added to RHEL via the installer RPM instead of copying the file from a local source.

- Enable Ansible RPM source via subscription manager
- Install AAP installer via DNF
- Update installer path to use default AAP installer location